### PR TITLE
updated RSS queries.

### DIFF
--- a/server/controllers/rssController.js
+++ b/server/controllers/rssController.js
@@ -1,85 +1,110 @@
 const axios = require('axios');
 const parser = new require('xml2js').Parser( {explicitArray: false});
-const NYTCategories = require('../static/categories').NYT
+const Sources = require('../static/categories');
 const controllers = {};
 
 controllers.getTransformRSS = (req, res, next) => {
-
+  // we should probbly use query params here for search and filter. 
+  console.log(req.query.categories);
+  // if the cateogry they're searching for doesn't exist we should move on. 
+  const categories = ['Science_and_Technology'];
   const combiner = []
   
-  for (const category of NYTCategories) {
-    const url = `https://rss.nytimes.com/services/xml/rss/nyt/${category}.xml`
-    combiner.push(axios.get(url).then(xmlRes => {
-      return {
-        category: category,
-        data: xmlRes
-      }
-    }))
-  }
-  
+// First loop through each category they have queried
+  categories.forEach(category => {
+
+    // for each category, we will check all available sources for new on that category
+    for (const source in Sources) {
+      // 'search' - is the current source we're considering
+      const search = Sources[source]; 
+      // 'Name' is a property of each source, it is the normal spelling for the source
+      const name = search.name;
+      // query URLs is a function availbe to the Source Class (see ./static/categories.js). This function will take all
+      // of the sub-categories in this source and create the apporpriate url for our GET request. 
+      const queryURLs = search.getQueryURLs(category);
+      // check if this source has the specified category of news, if not ocntinue to next one. This function returns false if there 
+      // is no appropriate category for that source. 
+      if (!queryURLs) continue; 
+
+
+      // begin pushing queries into the combiner that will use promise.all to concurrently (I think) process the get requests. 
+      combiner.push(...queryURLs.map(url => {
+        // make a get reuquest to the source for all relevant news
+        return axios.get(url)
+          .then(xmlRes => {
+             // use our parsing library 'https://www.npmjs.com/package/xml2js' to tranform the XLM data into an object representation
+            return parser.parseStringPromise(xmlRes.data);
+            }
+          )
+          .then(data => {
+            // Use a helper function (see below) to pick out the specifc fields we care about in the object.
+            // NOTE: These objects are deeply nested, should add additonal optional chaining to ensure better error handling. 
+            return normalizeRSSObj(data, category, name)
+          })
+          .catch(err => {
+            // This is our catch all for any querying errors - by defualt this will return an empty array to avoid errors in the 
+            // reducer function below (see promise.all)
+            console.log(`Failure in request to ${name} for: ${category} at: ${err.request.path}\n Message: ${err.message}\n Check URL path for error in spelling, spacing.`);
+            return [];
+          })
+      }))
+    }
+  })
+
+  // Using promise to all to wait for the queries after rapidly firing them off. 
   Promise.all(combiner)
     .then(responses => {
-      return Promise.all(responses.map(xml => {
-        const data = xml.data;
-        const category = xml.category;
-        return parser.parseStringPromise(data.data).then(parsed => {
-          return {
-            category: category,
-            data: parsed
-          }
-        });
-      }))
+      // each response should be normalized now and will be an array of objects.
+      // using a reduce below to combine each of these arrays for delivery to client. 
+      res.locals.data = responses.reduce((acc, currArr) => {
+        acc.push(...currArr);
+        return acc;
+      })
+
+      // if the data is empty this would indicate an error in all of the queries or a lack of data. 
+      if (!res.locals.data.length) throw new Error('no data was received');
+      next();
     })
-    .then(data => {
-      res.locals.data = data.reduce(
-        (acc, curr) => {
-          acc.push(...normalizeRSSObj(curr.data, curr.category))
-          return acc
-        }, [])
-      
-      return next();
-    })
-    .catch (err => {
+    .catch(err => {
+      // an error at this stage should be unlikely, but would likely come from our intial queries.
         return next({
           log: 'Failure in get Middleware',
           status: 500,
           message: {err: err.message}
       })
     })
-  // axios.get(url)
-  //   .then((response) => {
-  //     const data = response.data; 
-  //     return parser.parseStringPromise(data);
-  //   })
-  //   .then(data => {
-  //     res.locals.data = normalizeRSSObj(data); 
-  //     return next();
-  //   })
-  //   
 }
 
-function normalizeRSSObj(data, category) {
-  // navigating thorugh first level of nesting. 
-  const rss = data.rss;
-  // sorting some of the meta data - may be useful down the road. 
-  const metaData = rss.$ || null;
-  // channnel has detailed data about this rss feed i.e., publish date, copyright, build date, language, etc... 
-  const channel = rss.channel;
-  // These are the individucal posts. 
-  const items = channel.item.map(post => {
-    console.log(post);
-    const newPost = {
-      title: post.title,
-      link: post.link,
-      pubDate: post.pubDate,
-      img: post['media:content']?.$ || null,
-      author: post['dc:creator'],
-      category: category
-    }
-    return newPost
-  });
-
-  return items
+function normalizeRSSObj(data, category, source) {
+  try {
+    // navigating thorugh first level of nesting. 
+    const rss = data.rss;
+    // sorting some of the meta data - may be useful down the road. 
+    const metaData = rss.$ || null;
+    // channnel has detailed data about this rss feed i.e., publish date, copyright, build date, language, etc... 
+    const channel = rss.channel;
+    // These are the individucal posts. 
+    const items = channel.item.map(post => {
+      const newPost = {
+        title: post.title || null,
+        description: post.description || null,
+        link: post.link || null,
+        pubDate: post.pubDate || null,
+        img: post['media:content']?.$ || null,
+        author: post['dc:creator'] || null,
+        category: category,
+        source: source
+      }
+      return newPost
+    });
+     
+    // console.log(items); 
+    return items
+  } catch (err) {
+    // still figuring out what the best wy to handle errors at this stage is.
+    console.log(`Failure in RSS Normalization`)
+    return [];
+  }
 }
 
 

--- a/server/routes/apiRouter.js
+++ b/server/routes/apiRouter.js
@@ -5,25 +5,27 @@ const Router = express.Router();
 
 
 
-Router.get('/',
-  apiController.getTransformRSS,
-  (req, res) => {
-    return res.status(200).json({ data: res.locals.data })
-  })
 
 
 Router.post('/login',
-  // pgContorller.validateUser,
-  (req, res) => {
-    console.log(req.session);
-    return res.status(200).json(res.locals.validationResponse);
-  })
+pgContorller.validateUser,
+(req, res) => {
+  console.log(req.session);
+  return res.status(200).json(res.locals.validationResponse);
+})
 
 
 Router.get('/user')
 Router.post('/user')
 Router.put('/user')
 
+
+
+Router.get('/',
+  apiController.getTransformRSS,
+  (req, res) => {
+    return res.status(200).json({ data: res.locals.data })
+  })
 
 
 module.exports = Router

--- a/server/server.js
+++ b/server/server.js
@@ -9,6 +9,8 @@ const app = express();
 const port = 3000;
 const apiRouter = require('./routes/apiRouter');
 
+app.set('query parser', 'simple');
+
 //using express json() so we have access to the body
 app.use(express.json());
 app.use(session({

--- a/server/static/categories.js
+++ b/server/static/categories.js
@@ -1,63 +1,58 @@
+class Source {
+  constructor(name, { url, extension }, categories) {
+    this.name = name;
+    this.$ = {
+      url: url,
+      extension: extension || ''
+    }
+    this.categories = categories
+  }
+
+  getQueryURLs(category) {
+    if (this.categories[category]) {
+      return this.categories[category].map(cat => `${this.$.url}${cat}${this.$.extension}`)
+    }
+    return false; 
+  }
+}
+
+// Base url `https://rss.nytimes.com/services/xml/rss/nyt/${category}.xml`
+const NYT = {
+  Sports: ['Baseball', 'Golf', 'Hockey', 'Soccer', 'Sports', 'Tennis', 'ProFootball', 'ProBasketball', 'CollegeFootball', 'CollegeBasketball', 'Automobiles'],
+  World: ['Africa', 'Americas', 'AsiaPacific', 'Europe', 'MiddleEast', 'World'],
+  Economy: ['Business', 'Economy', 'SmallBusiness', 'RealEstate', 'YourMoney', 'MediaandAdvertising', 'Dealbook', 'Jobs',],
+  Arts_and_Culture: ['ArtandDesign', 'Arts', 'Dance', 'DiningandWine', 'FashionandStyle', 'Movies', 'Music', 'SundayBookReview', 'Theater', 'Television', 'Travel', 'Books'],
+  Issues: ['EnergyEnvironment', 'Politics', 'US', 'Climate', 'Education', 'Health'],
+  Popular: ['MostViewed', 'MostShared', 'MostEmailed'], 
+  Science_and_Technology: ['PersonalTech', 'Space', 'Science', 'Technology'],
+  NY: ['NYRegion',],
+  Miscellaneous: ['HomePage', 'Lens',  'Obituaries', 'Sunday-Review', 'TMagazine', 'Upshot', 'Weddings', 'Well',] 
+}
+
+// base url http://feeds.feedburner.com/ign/${category} - articles
+// http://feeds.feedburner.com/ignfeeds/podcasts/${category} - Podcasts interesting, but probably a stretch right now
+const IGN = {
+  Science_and_Technology: ['tech-articles'],
+  Arts_and_Culture: ['movies-articles'],
+  Games: [ 'games-all']
+}
+ 
+ // base url https://feeds.a.dj.com/rss/${category}.xml
+const WSJ = {
+  Economy: ['WSJcomUSBusiness', 'RSSMarketsMain'],
+  Science_and_Technology: ['RSSWSJD'],
+  World: ['RSSWorldNews'],
+  Arts_and_Culture: ['RSSLifestyle'],
+  Miscellaneous: [ 'RSSOpinion',]
+ }
+
+
+const NYTSource = new Source('New York Times', { url: 'https://rss.nytimes.com/services/xml/rss/nyt/', extension: '.xml' }, NYT);
+const WSJSource = new Source('Wall Street Journal', { url: 'https://feeds.a.dj.com/rss/', extension: '.xml' }, WSJ);
+const IGNSource = new Source('IGN', { url: 'http://feeds.feedburner.com/ign/'}, IGN);
+
 module.exports = {
-  NYT: [
-    'Africa',
-    'Americas',
-    'ArtandDesign',
-    'Arts',
-    'AsiaPacific',
-    'Automobiles',
-    'Baseball',
-    'Books',
-    'Business',
-    'Climate',
-    'CollegeBasketball',
-    'CollegeFootball',
-    'Dance',
-    'Dealbook',
-    'DiningandWine',
-    'Economy',
-    'Education',
-    'EnergyEnvironment',
-    'Europe',
-    'FashionandStyle',
-    'Golf',
-    'Health',
-    'Hockey',
-    'HomePage',
-    'Jobs',
-    'Lens',
-    'MediaandAdvertising',
-    'MiddleEast',
-    'MostEmailed',
-    'MostShared',
-    'MostViewed',
-    'Movies',
-    'Music',
-    'NYRegion',
-    'Obituaries',
-    'PersonalTech',
-    'Politics',
-    'ProBasketball',
-    'ProFootball',
-    'RealEstate',
-    'Science',
-    'SmallBusiness',
-    'Soccer',
-    'Space',
-    'Sports',
-    'SundayBookReview',
-    'Sunday-Review',
-    'Technology',
-    'Television',
-    'Tennis',
-    'Theater',
-    'TMagazine',
-    'Travel',
-    'Upshot',
-    'US',
-    'Weddings',
-    'Well',
-    'World',
-    'YourMoney',
-    ], 
+  NYTSource,
+  WSJSource,
+  IGNSource
 }


### PR DESCRIPTION
Used class syntax to create source obj for adding new sources. This will make it easier to rapidly include more sources in the future. Cleaned up RSS feed queries and use of promise.all.

Added WSJ and IGN to supported news sources in queries. 

Added some parameters for the query strings, hopefully we can use those instead of request body. 

Also added more extensive error handling and commenting throughout.